### PR TITLE
feat(cd): Adding automation to shelley-cms

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - run: npm ci
@@ -27,7 +27,7 @@ jobs:
     needs: install
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache/restore@v3
@@ -50,7 +50,7 @@ jobs:
     needs: build-types
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -77,7 +77,7 @@ jobs:
     needs: build-types
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -104,7 +104,7 @@ jobs:
     needs: [lint, typecheck]
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
@@ -131,7 +131,7 @@ jobs:
     needs: unit-tests
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish to NPM
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "18.x"
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies and build
+        run: npm ci && npm run build
+      - name: Publish package on NPM
+        run: cd dist; npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 # engine-strict=true
+tag-version-prefix=""


### PR DESCRIPTION
Currently we rely on a manual process to publish new packages. This hopes to start the journey to automate that process.

This PR will require the following process in order to trigger a release:

- `npm version x.x.x` based on previous commits/merges.
- `git push origin --tags`
- Manually create a release for the pushed tag https://docs.github.com/en/github/administering-a-repository/releasing-projects-on-github/managing-releases-in-a-repository

## Other information
- I suggest we drop running lower version of Node (14, 16) for Github actions as we're not likely to encounter any issues on a node version level.

## Future ideas
- Auto document release
- Run publish to npm job after git tag opposed to a release