### PR TITLE
design: general snagging updates 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.14",
       "license": "ISC",
       "dependencies": {
-        "@actionishope/shelley": "^4.1.6",
+        "@actionishope/shelley": "^4.1.7",
         "@react-hook/size": "^2.1.2",
         "is-hotkey": "^0.2.0",
         "is-url": "^1.2.4",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@actionishope/shelley": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@actionishope/shelley/-/shelley-4.1.6.tgz",
-      "integrity": "sha512-AIghw7tr1MI2Wutjmiw/o0RUaGfLHSwZTHf7C7IdD2haxjbPQH2HHa007r0MYk6PX4q34P++vj4q6QpBXDuKdQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@actionishope/shelley/-/shelley-4.1.7.tgz",
+      "integrity": "sha512-5z6yNjS2URHAGrNqdjGQHjrWCKBnGD2SsGQO6jTIZ2UMhOoNu9bn95yxXb5VObU7QgQOU6hJlcUR8RV4uOQ0GA==",
       "dependencies": {
         "@react-aria/toast": "^3.0.0-beta.7",
         "@react-aria/utils": "^3.22.0",
@@ -35469,9 +35469,9 @@
   },
   "dependencies": {
     "@actionishope/shelley": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@actionishope/shelley/-/shelley-4.1.6.tgz",
-      "integrity": "sha512-AIghw7tr1MI2Wutjmiw/o0RUaGfLHSwZTHf7C7IdD2haxjbPQH2HHa007r0MYk6PX4q34P++vj4q6QpBXDuKdQ==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@actionishope/shelley/-/shelley-4.1.7.tgz",
+      "integrity": "sha512-5z6yNjS2URHAGrNqdjGQHjrWCKBnGD2SsGQO6jTIZ2UMhOoNu9bn95yxXb5VObU7QgQOU6hJlcUR8RV4uOQ0GA==",
       "requires": {
         "@react-aria/toast": "^3.0.0-beta.7",
         "@react-aria/utils": "^3.22.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@actionishope/shelley": "^4.1.6",
+    "@actionishope/shelley": "^4.1.7",
     "@react-hook/size": "^2.1.2",
     "is-hotkey": "^0.2.0",
     "is-url": "^1.2.4",

--- a/src/components/Chip/Chip.tsx
+++ b/src/components/Chip/Chip.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, ReactNode } from "react";
 import { st, classes } from "./chip.st.css";
 import { Button } from "@actionishope/shelley/Button";
 import { Text } from "@actionishope/shelley/Text";
-import { Trash } from "../icons";
+import { CloseSmall } from "../icons";
 
 // todo: Update and promote to Shelley.
 export interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {
@@ -42,7 +42,7 @@ function Chip(props: ChipProps, ref: React.Ref<HTMLBaseElement>) {
           className={classes.removeButton}
           tone={10}
           variant="fab"
-          icon={deleteIcon ?? <Trash alt={onRemoveAltText} />}
+          icon={deleteIcon ?? <CloseSmall alt={onRemoveAltText} />}
           vol={1}
           onPress={onRemove}
         />

--- a/src/components/ContentActions/ContentActions.tsx
+++ b/src/components/ContentActions/ContentActions.tsx
@@ -11,9 +11,11 @@ import {
 } from "@actionishope/shelley/Dialog";
 import type { shards } from "src/typings/shared-types";
 import { st, classes } from "./contentActions.st.css";
+import type { ComponentBase } from "@actionishope/shelley";
 export interface ContentActionsProps
   extends Omit<React.HTMLProps<HTMLDivElement>, "type" | "ref">,
-    Pick<DialogTriggerProps, "isOpen" | "onOpenChange"> {
+    Pick<DialogTriggerProps, "isOpen" | "onOpenChange">,
+    ComponentBase {
   shards?: shards;
 }
 function ContentActions(
@@ -26,12 +28,18 @@ function ContentActions(
     shards,
     isOpen,
     onOpenChange,
+    "data-id": dataId,
     ...rest
   } = props;
 
   const targetRef = useRef(null);
   return (
-    <div className={st(classes.root, classNameProp)} {...rest} ref={ref}>
+    <div
+      className={st(classes.root, classNameProp)}
+      {...rest}
+      ref={ref}
+      data-id={dataId}
+    >
       <DialogTrigger
         portalSelector="#portal"
         isOpen={isOpen}
@@ -44,15 +52,19 @@ function ContentActions(
       >
         <Button
           vol={4}
-          variant="secondary"
           tone={1}
-          ref={targetRef}
+          variant="secondary"
           className={classes.addBlockButton}
+          ref={targetRef}
+          data-id={dataId ? `${dataId}--addContentButton` : undefined}
         >
           Add Content Block
         </Button>
         {(close) => (
-          <Dialog className={classes.dialog}>
+          <Dialog
+            className={classes.dialog}
+            data-id={dataId ? `${dataId}--dialog` : undefined}
+          >
             <VisuallyHidden>
               <H2 vol={1} uppercase className={dialog.title} data-title>
                 Adding and managing block order
@@ -60,7 +72,11 @@ function ContentActions(
             </VisuallyHidden>
             <div className={dialog.content}>{children}</div>
             <ButtonGroup className={dialog.buttonGroup}>
-              <Button variant="secondary" onPress={close}>
+              <Button
+                variant="secondary"
+                onPress={close}
+                data-id={dataId ? `${dataId}--dialog--closeButton` : undefined}
+              >
                 Close
               </Button>
             </ButtonGroup>

--- a/src/components/MediaField/MediaField.tsx
+++ b/src/components/MediaField/MediaField.tsx
@@ -50,7 +50,7 @@ const MediaField = ({
     <div
       className={st(
         classes.root,
-        { type, hasPreview: Boolean(mediaPreview), vol: vol !== false ? vol : undefined },
+        { type, hasPreview: Boolean(mediaPreview), hasChildren: Boolean(selectedMediaHelp) || Boolean(children), vol: vol !== false ? vol : undefined },
         className
       )}
     >
@@ -85,14 +85,14 @@ const MediaField = ({
                 variant="fab"
                 className={classes.editButton}
                 onPress={onRemove}
-                vol={2}
+                vol={vol === 3 ? 2 : 1}
                 icon={<Trash alt={removeText} />}
               />
               <Button
                 variant="fab"
                 className={classes.editButton}
                 onPress={onEdit}
-                vol={2}
+                vol={vol === 3 ? 2 : 1}
                 icon={<Edit alt={editText} />}
               />
             </nav>

--- a/src/components/MediaField/mediaField.st.css
+++ b/src/components/MediaField/mediaField.st.css
@@ -6,6 +6,7 @@
   -st-states:
     type(enum(icon, video, image, document)),
     hasPreview,
+    hasChildren,
     vol(number)
 }
 
@@ -16,10 +17,8 @@
 }
 
 .grid {
+  justify-content: start;
   display: grid;
-  grid-template-columns: 50px 20px 1fr;
-  grid-template-areas: 'trigger orText children';
-  align-items: center;
   margin: 0;
 }
 
@@ -31,7 +30,7 @@
   grid-area: orText;
 }
 
-.root:hasPreview::grid {
+.root:hasPreview:hasChildren::grid {
   grid-template-areas:
     'preview alt'
     'preview caption'

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -144,7 +144,6 @@ function PageActions<T extends { key: string }>(
             className={classes.statusIndicator}
             status={status}
           />
-          {/* <span className={st(classes.led, classes[status])}></span> */}
           <strong>{strings.status}</strong> {strings[status]}
         </Text>
         {/* @todo: shelley -> Button group us adding extra props to the MenuTrigger in this scenario */}

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -13,19 +13,14 @@ import { Icon } from "@actionishope/shelley/Icon";
 import { st, classes } from "./pageActions.st.css";
 import { classes as spacing } from "@actionishope/shelley/styles/default/spacing.st.css";
 import { ProgressCircle } from "@actionishope/shelley";
-
-export type statusOptions =
-  | "published"
-  | "draft"
-  | "updated"
-  | "archived"
-  | "unpublished";
+import { StatusIndicator } from "../StatusIndicator/StatusIndicator";
+import type { StatusOptions } from "../../typings/shared-types";
 
 export interface PageActionsProps<T>
   extends Omit<React.HTMLAttributes<HTMLDivElement>, "children">,
     ComponentBase {
   /** Provide a status */
-  status: statusOptions;
+  status: StatusOptions;
   /** The last saved value, e.g "a week ago", "a few minutes" etc. */
   lastSaved?: string;
   lastSavedDateTime?: string;
@@ -145,8 +140,11 @@ function PageActions<T extends { key: string }>(
           className={st(spacing.mb1, classes.statusText)}
           data-id={dataId ? `${dataId}--status` : undefined}
         >
-          {/* @todo: Convert to StatusIndicator component */}
-          <span className={st(classes.led, classes[status])}></span>
+          <StatusIndicator
+            className={classes.statusIndicator}
+            status={status}
+          />
+          {/* <span className={st(classes.led, classes[status])}></span> */}
           <strong>{strings.status}</strong> {strings[status]}
         </Text>
         {/* @todo: shelley -> Button group us adding extra props to the MenuTrigger in this scenario */}
@@ -161,6 +159,7 @@ function PageActions<T extends { key: string }>(
                 <ProgressCircle
                   className={classes.loader}
                   size="small"
+                  data-id={dataId ? `${dataId}--saveIndicator` : undefined}
                   isIndeterminate
                   variant="overBackground"
                 />
@@ -182,7 +181,6 @@ function PageActions<T extends { key: string }>(
                   <path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>
                 </Icon>
               }
-              isDisabled
               className={classes.menuTrigger}
               data-id={dataId ? `${dataId}--menuTrigger` : undefined}
               vol={4}
@@ -190,7 +188,6 @@ function PageActions<T extends { key: string }>(
             />
             <Menu
               onAction={(key) => onActionProp(key)}
-              // disabledKeys={disabledKeys}
               disabledKeys={disabledKeysProp}
               className={classes.menu}
               data-id={dataId ? `${dataId}--menu` : undefined}

--- a/src/components/PageActions/PageActions.tsx
+++ b/src/components/PageActions/PageActions.tsx
@@ -12,6 +12,7 @@ import {
 import { Icon } from "@actionishope/shelley/Icon";
 import { st, classes } from "./pageActions.st.css";
 import { classes as spacing } from "@actionishope/shelley/styles/default/spacing.st.css";
+import { ProgressCircle } from "@actionishope/shelley";
 
 export type statusOptions =
   | "published"
@@ -48,6 +49,7 @@ export interface PageActionsProps<T>
     MenuTriggerProps,
     "placement" | "shouldFlip" | "offset" | "crossOffset" | "portalSelector"
   >;
+  isSaving?: boolean;
 }
 
 function PageActions<T extends { key: string }>(
@@ -65,6 +67,7 @@ function PageActions<T extends { key: string }>(
     onAction: onActionProp,
     "data-id": dataId,
     lastSavedDateTime,
+    isSaving = false,
     ...rest
   } = props;
 
@@ -153,6 +156,16 @@ function PageActions<T extends { key: string }>(
             variant="primary"
             tone={reviewRequired ? 2 : 1}
             className={classes.reviewButton}
+            icon={
+              isSaving && (
+                <ProgressCircle
+                  className={classes.loader}
+                  size="small"
+                  isIndeterminate
+                  variant="overBackground"
+                />
+              )
+            }
             data-id={dataId ? `${dataId}--actionButton` : undefined}
             fullWidth
             onPress={() =>
@@ -169,6 +182,7 @@ function PageActions<T extends { key: string }>(
                   <path d="M13 4v2l-5 5-5-5v-2l5 5z"></path>
                 </Icon>
               }
+              isDisabled
               className={classes.menuTrigger}
               data-id={dataId ? `${dataId}--menuTrigger` : undefined}
               vol={4}

--- a/src/components/PageActions/__tests__/__snapshots__/PageActions.test.tsx.snap
+++ b/src/components/PageActions/__tests__/__snapshots__/PageActions.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`PageActions renders page actions block with custom className 1`] = `
       className="Text__Test__root Text__Test---vol-1-1 DefaultSpacing__Test__mb1 PageActions__Test__statusText"
     >
       <span
-        className="PageActions__Test__led PageActions__Test__draft"
+        className="StatusIndicator__Test__root StatusIndicator__Test---status-5-draft StatusIndicator__Test---vol-1-2 PageActions__Test__statusIndicator"
       />
       <strong>
         Status:

--- a/src/components/PageActions/pageActions.st.css
+++ b/src/components/PageActions/pageActions.st.css
@@ -24,6 +24,8 @@
   -st-extends: Button;
 }
 
+.loader {}
+
 .menuTrigger {
   -st-extends: Button;
 }
@@ -70,6 +72,11 @@
 .updated {
   background-color: #15c8e8;
   border: 1px solid #75eaff;
+}
+
+.loader {
+  position: absolute;
+  right: 10px;
 }
 
 /* 

--- a/src/components/PageActions/pageActions.st.css
+++ b/src/components/PageActions/pageActions.st.css
@@ -39,66 +39,11 @@
   width: 100%;
 }
 
-/* @todo: Move to StatusIndicator comp */
-.led {
+.statusIndicator {
   margin: -2px 8px 0 0;
-  width: 12px;
-  height: 12px;
-  display: inline-block;
-  border-radius: 50%;
-  vertical-align: middle;
-}
-
-.archived {
-  background-color: #f05751;
-  border: 1px solid #d9453f;
-}
-
-.draft {
-  background-color: #fba012;
-  border: 1px solid #db8500;
-}
-
-.unpublished {
-  background-color: #fba012;
-  border: 1px solid #db8500;
-}
-
-.published {
-  background-color: #14d997;
-  border: 1px solid #0eb87f;
-}
-
-.updated {
-  background-color: #15c8e8;
-  border: 1px solid #75eaff;
 }
 
 .loader {
   position: absolute;
   right: 10px;
 }
-
-/* 
-@todo: Potentially add animation to the publlish button.
-.reviewButton {
-  -st-extends: Button;
-  background-color: #222;
-  animation-name: color;
-  animation-duration: 3s;
-  animation-iteration-count: infinite;
-}
-
-@keyframes color {
-  0% {
-    background-color: #16a78e;
-  }
-
-  50% {
-    background-color: #448688;
-  }
-
-  100% {
-    background-color: #16a78e;
-  }
-} */

--- a/src/components/PreviewMetaData/PreviewMetaData.tsx
+++ b/src/components/PreviewMetaData/PreviewMetaData.tsx
@@ -92,7 +92,7 @@ export const Google = ({
   slug,
   "data-id": dataId,
 }: PreviewMetaDataItemProps) => (
-  <article className={st(classes.previewItem, classes.google)}>
+  <article className={st(classes.previewItem, classes.google)} data-id={dataId}>
     <Icon
       viewBox="0 0 272 92"
       className={classes.googleLogo}
@@ -124,19 +124,19 @@ export const Google = ({
     <aside className={classes.googleListing}>
       <p
         className={classes.googleUrl}
-        data-id={dataId ? `${dataId}--googleUrl` : undefined}
+        data-id={dataId ? `${dataId}--url` : undefined}
       >
         {slug}
       </p>
       <p
         className={classes.googleTitle}
-        data-id={dataId ? `${dataId}--googleTitle` : undefined}
+        data-id={dataId ? `${dataId}--title` : undefined}
       >
         {title}
       </p>
       <p
         className={classes.googleDescription}
-        data-id={dataId ? `${dataId}--googleDescription` : undefined}
+        data-id={dataId ? `${dataId}--description` : undefined}
       >
         {description}
       </p>
@@ -151,7 +151,10 @@ export const Twitter = ({
   image,
   "data-id": dataId,
 }: PreviewMetaDataItemProps) => (
-  <article className={st(classes.previewItem, classes.twitter)}>
+  <article
+    className={st(classes.previewItem, classes.twitter)}
+    data-id={dataId}
+  >
     <Icon
       viewBox="0 0 400 400"
       className={classes.twitterLogo}
@@ -170,25 +173,25 @@ export const Twitter = ({
           className={classes.twitterImage}
           src={image}
           alt=""
-          data-id={dataId ? `${dataId}--twitterImage` : undefined}
+          data-id={dataId ? `${dataId}--image` : undefined}
         />
       )}
       <div className={classes.twitterText}>
         <p
           className={classes.twitterTitle}
-          data-id={dataId ? `${dataId}--twitterTitle` : undefined}
+          data-id={dataId ? `${dataId}--title` : undefined}
         >
           {title}
         </p>
         <p
           className={classes.twitterDescription}
-          data-id={dataId ? `${dataId}--twitterDescription` : undefined}
+          data-id={dataId ? `${dataId}--description` : undefined}
         >
           {description}
         </p>
         <p
           className={classes.twitterDomain}
-          data-id={dataId ? `${dataId}--twitterDomain` : undefined}
+          data-id={dataId ? `${dataId}--domain` : undefined}
         >
           <Icon viewBox="0 0 24 24" className={classes.twitterLinkIcon}>
             <g>
@@ -210,7 +213,10 @@ export const Facebook = ({
   image,
   "data-id": dataId,
 }: PreviewMetaDataItemProps) => (
-  <article className={st(classes.previewItem, classes.facebook)}>
+  <article
+    className={st(classes.previewItem, classes.facebook)}
+    data-id={dataId}
+  >
     <Icon
       viewBox="0 0 266.893 266.895"
       className={classes.facebookLogo}
@@ -236,24 +242,24 @@ export const Facebook = ({
             className={classes.facebookImage}
             src={image}
             alt=""
-            data-id={dataId ? `${dataId}--facebookImage` : undefined}
+            data-id={dataId ? `${dataId}--image` : undefined}
           />
         )}
         <p
           className={classes.facebookDomain}
-          data-id={dataId ? `${dataId}--facebookDomain` : undefined}
+          data-id={dataId ? `${dataId}--domain` : undefined}
         >
           {domain}
         </p>
         <p
           className={classes.facebookTitle}
-          data-id={dataId ? `${dataId}--facebookTitle` : undefined}
+          data-id={dataId ? `${dataId}--title` : undefined}
         >
           {title}
         </p>
         <p
           className={classes.facebookDescription}
-          data-id={dataId ? `${dataId}--facebookDescription` : undefined}
+          data-id={dataId ? `${dataId}--description` : undefined}
         >
           {description}
         </p>

--- a/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/src/components/StatusIndicator/StatusIndicator.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef, Ref } from "react";
+import { st, classes } from "./statusIndicator.st.css";
+import type { StatusOptions } from "../../typings/shared-types";
+
+// todo: Update and promote to Shelley.
+export interface StatusIndicatorProps
+  extends React.HTMLAttributes<HTMLSpanElement> {
+  status: StatusOptions;
+  vol: 1 | 2 | 3;
+}
+const StatusIndicator = forwardRef(
+  (
+    {
+      className: classNameProp,
+      status,
+      vol = 2,
+      ...rest
+    }: StatusIndicatorProps,
+    ref?: Ref<HTMLSpanElement>
+  ) => {
+    return (
+      <span
+        className={st(classes.root, { status, vol }, classNameProp)}
+        {...rest}
+        ref={ref}
+      />
+    );
+  }
+);
+
+StatusIndicator.displayName = "StatusIndicator";
+
+export { StatusIndicator };

--- a/src/components/StatusIndicator/StatusIndicator.tsx
+++ b/src/components/StatusIndicator/StatusIndicator.tsx
@@ -6,7 +6,7 @@ import type { StatusOptions } from "../../typings/shared-types";
 export interface StatusIndicatorProps
   extends React.HTMLAttributes<HTMLSpanElement> {
   status: StatusOptions;
-  vol: 1 | 2 | 3;
+  vol?: 1 | 2 | 3;
 }
 const StatusIndicator = forwardRef(
   (

--- a/src/components/StatusIndicator/statusIndicator.st.css
+++ b/src/components/StatusIndicator/statusIndicator.st.css
@@ -1,0 +1,51 @@
+/* statusIndicator.st.css */
+@st-namespace "StatusIndicator";
+
+.root {
+  -st-states:
+    status(enum(published, draft, updated, archived, unpublished)),
+    vol(number);
+  display: inline-block;
+  border-radius: 50%;
+  vertical-align: middle;
+}
+
+.root:vol(1) {
+  width: 8px;
+  height: 8px;
+}
+
+.root:vol(2) {
+  width: 10px;
+  height: 10px;
+}
+
+.root:vol(3) {
+  width: 12px;
+  height: 12px;
+}
+
+.root:status(archived) {
+  background-color: #f05751;
+  border: 1px solid #d9453f;
+}
+
+.root:status(draft) {
+  background-color: #fba012;
+  border: 1px solid #db8500;
+}
+
+.root:status(unpublished) {
+  background-color: #fba012;
+  border: 1px solid #db8500;
+}
+
+.root:status(published) {
+  background-color: #14d997;
+  border: 1px solid #0eb87f;
+}
+
+.root:status(updated) {
+  background-color: #15c8e8;
+  border: 1px solid #75eaff;
+}

--- a/src/components/icons/CloseCircle.tsx
+++ b/src/components/icons/CloseCircle.tsx
@@ -1,0 +1,13 @@
+import type React from "react";
+import type { Ref } from "react";
+import { Icon, IconProps } from "@actionishope/shelley/Icon";
+
+const CloseCircle: React.VFC<IconProps> = (props) => {
+  const { ref, ...rest } = props;
+  return (
+    <Icon {...rest} viewBox="0 0 24 24" ref={ref as Ref<SVGSVGElement>}>
+      <path d="M14.59 8 12 10.59 9.41 8 8 9.41 10.59 12 8 14.59 9.41 16 12 13.41 14.59 16 16 14.59 13.41 12 16 9.41 14.59 8zM12 2C6.47 2 2 6.47 2 12s4.47 10 10 10 10-4.47 10-10S17.53 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"></path>
+    </Icon>
+  );
+};
+export default CloseCircle;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -3,6 +3,7 @@ export { default as Bold } from "./Bold";
 export { default as AddToBoard } from "./AddToBoard";
 export { default as ArrowDown2 } from "./ArrowDown2";
 export { default as Calendar } from "./Calendar";
+export { default as CloseCircle } from "./CloseCircle";
 export { default as CloseSmall } from "./CloseSmall";
 export { default as CompressScreen } from "./CompressScreen";
 export { default as Content } from "./Content";

--- a/src/indexLib.ts
+++ b/src/indexLib.ts
@@ -4,7 +4,9 @@
 */
 
 /** Components exports in alphabetical order */
+export * from "./components/Badge/Badge";
 export * from "./components/BlockEditor/BlockEditor";
+export * from "./components/Chip/Chip";
 export * from "./components/ContentArea/ContentArea";
 export * from "./components/ContentActions/ContentActions";
 export * from "./components/Dashboard/Dashboard";
@@ -21,4 +23,6 @@ export * from "./components/PreviewMetaData/PreviewMetaData";
 export * from "./components/PreviewModes/PreviewModes";
 export * from "./components/ReorderItems/ReorderItems";
 export * from "./components/StaleContentWidget/StaleContentWidget";
+export * from "./components/StatusIndicator/StatusIndicator";
+export * from "./components/SlateArea/SlateArea";
 export * from "./components/UserWidget/UserWidget";

--- a/src/stories/UI/BlockEditor.examples.tsx
+++ b/src/stories/UI/BlockEditor.examples.tsx
@@ -120,6 +120,7 @@ export const BasicBlockEditor = (args: Partial<BlockEditorProps>) => {
           onAdd={() => console.log("Add Media")}
           onEdit={() => console.log("Edit Media")}
           onRemove={() => console.log("Remove media")}
+          vol={3}
           mediaPreview={
             <img
               src="https://ucarecdn.com/68d4e740-b645-4273-bf86-5752a208a6ce/-/crop/3863x2172/0,396/-/preview/-/format/auto/"
@@ -145,6 +146,12 @@ export const BasicBlockEditor = (args: Partial<BlockEditorProps>) => {
           }}
         </MediaField>
 
+        <MediaField
+          type="image"
+          onAdd={() => console.log("Add Media")}
+          onEdit={() => console.log("Edit Media")}
+          onRemove={() => console.log("Remove media")}
+        />
         <SlateArea vol={6} defaultValue={`Title`} name="title" />
         <SlateArea vol={3} defaultValue={`Description`} name="description" />
         <Select

--- a/src/stories/UI/EditorLayout.examples.tsx
+++ b/src/stories/UI/EditorLayout.examples.tsx
@@ -69,10 +69,12 @@ export const BasicExample = () => {
             // @todo: https://github.com/action-is-hope/shelley/issues/106
             isOpen={contentActionDialogOpen}
             onOpenChange={(isOpen) => setContentActionDialogOpen(isOpen)}
+            data-id="contentActions"
           >
             <Tabs
               aria-label="History of Ancient Rome"
               className={contentActions.tabs}
+              data-id="contentActions--tabs"
             >
               <Item key="FoR" title="Add Block">
                 <Checkbox

--- a/src/stories/UI/Finder.examples.tsx
+++ b/src/stories/UI/Finder.examples.tsx
@@ -20,6 +20,7 @@ import { classes as finder } from "../../styles/cms/finder.st.css";
 
 export const BasicExample = () => (
   <Finder
+    data-id="finder"
     title={
       <>
         <ContentIcon aria-hidden="true" />

--- a/src/stories/UI/MediaField.stories.mdx
+++ b/src/stories/UI/MediaField.stories.mdx
@@ -42,9 +42,7 @@ MediaField is a generic UI for displaying adding and displaying media items.
     },
   }}
 >
-  <MediaField vol={2} onAdd={() => console.log("Add Media")}>
-    Hi
-  </MediaField>
+  <MediaField vol={1} onAdd={() => console.log("Add Media")}></MediaField>
 </Story>
 
 <Source language="tsx" id="editor-mediafield--a-media-field" />

--- a/src/stories/UI/MetaDataEditor.examples.tsx
+++ b/src/stories/UI/MetaDataEditor.examples.tsx
@@ -2,6 +2,7 @@ import { TextField, Select, Item } from "@actionishope/shelley";
 import { MetaDataEditor } from "../../components/MetaDataEditor/MetaDataEditor";
 import { classes } from "../../components/MetaDataEditor/metaDataEditor.st.css";
 import { useState, SetStateAction } from "react";
+import { MediaField } from "../../components/MediaField/MediaField";
 
 export const MetaDataEditorExample = () => {
   const [langauge, setLanguage] = useState("en");
@@ -22,9 +23,18 @@ export const MetaDataEditorExample = () => {
       }
       // Provide Media Uploader
       mediaUploader={
-        <img
-          src="https://ucarecdn.com/68d4e740-b645-4273-bf86-5752a208a6ce/-/crop/3863x2172/0,396/-/preview/-/format/auto/"
-          alt=""
+        <MediaField
+          type="image"
+          onAdd={() => console.log("Add Media")}
+          onEdit={() => console.log("Edit Media")}
+          onRemove={() => console.log("Remove media")}
+          vol={2}
+          mediaPreview={
+            <img
+              src="https://ucarecdn.com/68d4e740-b645-4273-bf86-5752a208a6ce/-/crop/3863x2172/0,396/-/preview/-/format/auto/"
+              alt=""
+            />
+          }
         />
       }
       // Title field props

--- a/src/stories/UI/PageActions.examples.tsx
+++ b/src/stories/UI/PageActions.examples.tsx
@@ -2,10 +2,10 @@ import { useState } from "react";
 import {
   PageActionsProps,
   PageActions,
-  statusOptions,
 } from "../../components/PageActions/PageActions";
 
 import { Item } from "@actionishope/shelley";
+import type { StatusOptions } from "../../typings/shared-types";
 
 // @todo Attempt (again) to get the automatic args table working in storybook. This is cause seemingly by using Omit, Pick etc
 export type PageActionsPropsDocs = PageActionsProps<object>;
@@ -14,7 +14,7 @@ export function PageActionsType(props: PageActionsPropsDocs) {
 }
 
 export const BasicExample = (args: PageActionsPropsDocs) => {
-  const [status, setStatus] = useState<statusOptions>("draft");
+  const [status, setStatus] = useState<StatusOptions>("draft");
   const [reviewRequired, setReviewRequired] = useState(true);
 
   return (

--- a/src/stories/UI/PageActions.examples.tsx
+++ b/src/stories/UI/PageActions.examples.tsx
@@ -24,6 +24,7 @@ export const BasicExample = (args: PageActionsPropsDocs) => {
       lastSavedDateTime="17:29 - 5th November 2023"
       reviewRequired={reviewRequired}
       position={{ portalSelector: "#portal" }}
+      data-id="pageActions"
       {...args}
       onAction={(actionKey) => {
         switch (actionKey) {

--- a/src/stories/UI/Preview.examples.tsx
+++ b/src/stories/UI/Preview.examples.tsx
@@ -31,6 +31,7 @@ export const BasicExample = () => {
       >
         {previewMode === "web" && (
           <PreviewMetaData
+            data-id="previewMetaData"
             title="Shelley Puma UI"
             description="A joyfully easy to use CMS UI built upon a little known library called Shelley."
             image="https://ik.imagekit.io/tcvka0ufln/pontoon_v3jIy64zcnwwx.jpeg?tr=w-1200,h-630,fo-auto"
@@ -40,7 +41,7 @@ export const BasicExample = () => {
           />
         )}
         {previewMode !== "web" && (
-          <PreviewChrome {...previewChromeProps}>
+          <PreviewChrome {...previewChromeProps} data-id="previewChrome">
             {/* Children... */}
             <div className={st(previewChrome.iframe)}>
               {/* Mimic the preview styles. If the preview is not white, set height too 100% and round corners for mobile preview. */}
@@ -65,6 +66,7 @@ export const BasicExample = () => {
       </Preview>
 
       <PreviewActions
+        data-id="previewActions"
         // className={editorLayout.previewActions}
         {...previewActionsProps}
       />

--- a/src/stories/UI/PreviewModes.examples.tsx
+++ b/src/stories/UI/PreviewModes.examples.tsx
@@ -12,6 +12,7 @@ export const BasicExample = () => {
     <>
       <PreviewModes
         className={"custom-class"}
+        data-id="previewModes"
         value={mode}
         onChange={(key) => {
           console.log(key);

--- a/src/stories/UI/ReorderItems.examples.tsx
+++ b/src/stories/UI/ReorderItems.examples.tsx
@@ -45,6 +45,7 @@ export const ReorderBlocksExample = () => {
       //     }
       title={"Reorder Content Blocks"}
       items={blocks}
+      data-id="reorderContentBlocks"
       onRemoveSelect={(index) => console.log("Index", index)}
       moveItem={({ fromIndex, toIndex }) => {
         const items = Array.from(blocks);

--- a/src/styles/cms/mediaField.st.css
+++ b/src/styles/cms/mediaField.st.css
@@ -9,7 +9,7 @@
 ] from "./project.st.css";
 
 @st-import BlockEditor, [menu] from "../../components/BlockEditor/blockEditor.st.css";
-@st-import MediaField from "../../components/MediaField/mediaField.st.css";
+@st-import MediaField , [grid] from "../../components/MediaField/mediaField.st.css";
 
 @st-import Modal, [
   enter,
@@ -37,17 +37,23 @@
     grid-gap: var(--spacing-unit);
   }
 
-  MediaField::grid {
-    grid-template-columns: 48px 16px 1fr;
+  MediaField:hasChildren:not(:hasPreview)::grid {
+    grid-template-areas: 'trigger orText children';
+    align-items: center;
     grid-column-gap: calc(var(--spacing-unit) * 1);
   }
 
-  MediaField:vol(1)::grid {
+  MediaField:hasChildren:not(:hasPreview):vol(1)::grid {
     grid-template-columns: 32px 16px 1fr;
   }
 
-  MediaField:vol(2)::grid {
+  MediaField:hasChildren:not(:hasPreview):vol(2)::grid {
     grid-template-columns: 40px 16px 1fr;
+  }
+
+  MediaField:hasChildren:not(:hasPreview):vol(3)::grid {
+    grid-template-columns: 48px 16px 1fr;
+    ;
   }
 
   MediaField::orText {
@@ -56,7 +62,7 @@
     justify-self: center;
   }
 
-  MediaField:hasPreview::grid {
+  MediaField:hasPreview:hasChildren::grid {
     grid-template-columns: 1fr 1fr;
     grid-row-gap: 0;
     grid-template-areas:
@@ -69,7 +75,7 @@
 
 @media value(breakpoint-sm) {
   @st-scope CMS {
-    MediaField:hasPreview::grid {
+    MediaField:hasPreview:hasChildren::grid {
       grid-template-areas:
         'preview alt'
         'preview caption'

--- a/src/styles/cms/metaDataEditor.st.css
+++ b/src/styles/cms/metaDataEditor.st.css
@@ -147,7 +147,7 @@
     grid-area: children;
     display: grid;
     gap: calc(var(--spacing-unit) * 1.5);
-    padding: 4px calc(47px + var(--spacing-unit)) calc(var(--spacing-unit) * 1.5) 0
+    padding: calc(var(--spacing-unit) * 1.5) calc(47px + var(--spacing-unit)) calc(var(--spacing-unit) * 1.5) 0
   }
 
   /* Generic Fields */

--- a/src/styles/cms/metaDataEditor.st.css
+++ b/src/styles/cms/metaDataEditor.st.css
@@ -11,6 +11,7 @@
   --color-form-base-border
 ] from "./project.st.css";
 @st-import MetaDataEditor from "../../components/MetaDataEditor/metaDataEditor.st.css";
+@st-import MediaField from "../../components/MediaField/mediaField.st.css";
 @st-import Field from "@actionishope/shelley/Field/field.st.css";
 @st-import Modal, [blurBackground] from "@actionishope/shelley/Modal/modal.st.css";
 
@@ -29,6 +30,18 @@
 @st-scope CMS {
   MetaDataEditor {
     --currentHeight: var(--height-header-md);
+  }
+
+  MetaDataEditor MediaField {
+    margin: 0;
+  }
+
+  MetaDataEditor MediaField:hasPreview::grid {
+    grid-gap: 0;
+  }
+
+  MetaDataEditor MediaField:hasPreview::editControls::after {
+    display: none;
   }
 }
 
@@ -76,6 +89,7 @@
     display: flex;
     align-items: center;
     height: var(--currentHeight);
+    justify-self: center;
   }
 
   MetaDataEditor::mediaUploader img {

--- a/src/styles/cms/progressCircle.st.css
+++ b/src/styles/cms/progressCircle.st.css
@@ -2,6 +2,7 @@
 @st-import Shelley, [
     --light-01-raw,
     --color-ui-raw,
+    --color-ui-raw-inverse,
     --color-accent-1,
   ] from "./project.st.css";
 @st-import ProgressCircle, [
@@ -16,7 +17,8 @@
   }
 
   ProgressCircle:variant(overBackground) {
-    --loader-circle-track-fill-color: var(--color-accent-1);
-    --loader-circle-track-color: rgba(var(--color-ui-raw), 0.2)
+    --loader-circle-track-fill-color: rgba(var(--color-ui-raw-inverse), 0.8);
+    --loader-circle-track-color: rgba(var(--color-ui-raw-inverse), 0.3)
   }
+
 }

--- a/src/typings/shared-types.d.ts
+++ b/src/typings/shared-types.d.ts
@@ -54,3 +54,10 @@ export interface Site {
 }
 
 export type shards = Array<React.RefObject<any> | HTMLElement> | undefined;
+
+export type StatusOptions =
+  | "published"
+  | "draft"
+  | "updated"
+  | "archived"
+  | "unpublished";


### PR DESCRIPTION
- swap out default `onRemove` icon for `Chip`
- add loading state to `PageActions`
- add `data-id`'s, 
- amend padding on `MetaDataEditor` content area.
- Update styles to allow `MediaField` to fit properly inside `MetaDateEditor`
- Bumps Shelley to fix issue with Toast and dataId updates -> https://github.com/action-is-hope/shelley/releases/tag/4.1.7