### PR TITLE
Make sure substraction happens even if any of the values is 0

### DIFF
--- a/src/components/StaleContentWidget/StaleContentWidget.tsx
+++ b/src/components/StaleContentWidget/StaleContentWidget.tsx
@@ -24,9 +24,11 @@ function StaleContentWidget(
   } = props;
 
   const freshContent =
-    circleProps.maxValue &&
-    circleProps.value &&
-    circleProps.maxValue - circleProps.value;
+    typeof circleProps.maxValue === "number" &&
+    typeof circleProps.value === "number"
+      ? circleProps.maxValue - circleProps.value
+      : 0;
+
   return (
     <Widget
       className={st(classes.root, classNameProp)}


### PR DESCRIPTION
Fix the issue when either `circleProps.maxValue` or `circleProps.value` is `0` and therefore `falsy` the `freshContent` calculation does not happen as short circuiting results in a value of `0`.

From, now on with this fix we can make sure the values exist as numbers and when they do, we can calculate `freshContent` properly.
